### PR TITLE
security(fastify-multipart): update

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = require('fastify-plugin')(fastifyArrowPlugin, {
 function fastifyArrowPlugin(fastify, opts, next) {
 
   if (!fastify.hasRequestDecorator('multipart')) {
-    fastify.register(require('fastify-multipart'), opts);
+    fastify.register(require('@fastify/multipart'), opts);
   }
 
   // Add a stub octet-stream parser so fastify doesn't reject payloads with content-type octet-stream

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/trxcllnt/fastify-arrow#readme",
   "dependencies": {
     "apache-arrow": "^5.0.0",
-    "fastify-multipart": "^4.0.7",
+    "@fastify/multipart": "^6.0.0",
     "fastify-plugin": "^3.0.0",
     "ix": "^4.5.0"
   },


### PR DESCRIPTION
Howdy! Dependency update to latest fastify 3 compatible version due to `fastify-multipart` CVEs